### PR TITLE
Link to google fonts with HTTPS

### DIFF
--- a/source/static-html/template/_meta.html
+++ b/source/static-html/template/_meta.html
@@ -7,5 +7,5 @@
 <meta name="description" content="{DESCRIPTION}">
 <meta name="robots" content="noindex, nofollow">
 
-<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300italic,700">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300italic,700">
 <link rel="stylesheet" href="assets/css/style.css" />


### PR DESCRIPTION
Fixes mixed content error if serving on HTTPS